### PR TITLE
Hedgedoc soft breaks

### DIFF
--- a/pkgs/by-name/he/hedgedoc/hedgedoc_soft_breaks_false_default.patch
+++ b/pkgs/by-name/he/hedgedoc/hedgedoc_soft_breaks_false_default.patch
@@ -1,0 +1,22 @@
+diff --git a/public/js/extra.js b/public/js/extra.js
+index d4d8ad7bf..ad631a822 100644
+--- a/public/js/extra.js
++++ b/public/js/extra.js
+@@ -187,7 +187,7 @@ export function isValidURL (str) {
+ export function parseMeta (md, edit, view, toc, tocAffix) {
+   let lang = null
+   let dir = null
+-  let breaks = true
++  let breaks = false
+   if (md && md.meta) {
+     const meta = md.meta
+     lang = meta.lang
+@@ -997,7 +997,7 @@ function highlightRender (code, lang) {
+ 
+ export const md = markdownit('default', {
+   html: true,
+-  breaks: true,
++  breaks: false,
+   langPrefix: '',
+   linkify: true,
+   typographer: true,

--- a/pkgs/by-name/he/hedgedoc/package.nix
+++ b/pkgs/by-name/he/hedgedoc/package.nix
@@ -10,6 +10,7 @@
   nixosTests,
   yarn-berry_4,
   writableTmpDirAsHomeHook,
+  enableSoftBreaks ? false,
 }:
 
 let
@@ -43,6 +44,8 @@ stdenv.mkDerivation {
   buildInputs = [
     nodejs # for shebangs
   ];
+
+  patches = [ ] ++ (if enableSoftBreaks then [ ./hedgedoc_soft_breaks_false_default.patch ] else [ ]);
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
